### PR TITLE
Agrega JpaBuilderConfig fuera del microservicio

### DIFF
--- a/src/main/java/com/edutech/plataforma_educativa/JpaBuilderConfig.java
+++ b/src/main/java/com/edutech/plataforma_educativa/JpaBuilderConfig.java
@@ -1,0 +1,21 @@
+package com.edutech.plataforma_educativa;
+
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+import java.util.Collections;
+
+@Configuration
+public class JpaBuilderConfig {
+
+    @Bean
+    public EntityManagerFactoryBuilder entityManagerFactoryBuilder() {
+        return new EntityManagerFactoryBuilder(
+            new HibernateJpaVendorAdapter(),
+            Collections.emptyMap(),
+            null
+        );
+    }
+}


### PR DESCRIPTION
Agrega JpaBuilderConfig fuera del microservicio que establece una configuración global de JPA para que en el futuro, cuando se agreguen nuevos microservicios, cada uno pueda tener una conexión independiente a base de datos mediante su propio DataSourceConfig y consumiendo una configuración global de JPA